### PR TITLE
Add dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  subversion \
+  git-core \
+  libncurses5-dev \
+  zlib1g-dev \
+  gawk \
+  bc \
+  cpio \ 
+  file \
+  flex \
+  quilt \
+  libssl-dev \
+  xsltproc \
+  libxml-parser-perl \
+  mercurial \
+  bzr \
+  ecj \
+  cvs \
+  unzip \
+  lib32z1 \
+  lib32z1-dev \
+  lib32stdc++6 \
+  libstdc++6 \
+  libncurses-dev \
+  u-boot-tools \
+  mkbootimg \
+  && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+	"build": {
+        "dockerfile": "Dockerfile"
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.cpptools-extension-pack",
+				"ms-vscode.makefile-tools"
+			]
+		}
+	}
+}


### PR DESCRIPTION
A dev container makes it easy to open this project on a new computer. VSCode can automatically setup the build environment using Docker.
https://containers.dev/