### PR TITLE
add shellcheck workflow and fix shellcheck errors

### DIFF
--- a/.github/worklows/dependabot.yml
+++ b/.github/worklows/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Look for `.github/workflows` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "monthly"
+    labels:
+      - "github_actions"

--- a/.github/worklows/shellcheck.yml
+++ b/.github/worklows/shellcheck.yml
@@ -1,0 +1,16 @@
+name: shellcheck
+on:
+  push:
+  workflow_dispatch:
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: run shellcheck
+        uses: luizm/action-sh-checker@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHELLCHECK_OPTS: --shell=sh --severity=warning --color=always
+        with:
+          sh_checker_comment: true

--- a/mkfw.sh
+++ b/mkfw.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 
-date=`date +%F`
+date=$(date +%F)
 
 version=$1
 
 if [ 1 != $# ]; then
 	echo please input version
 fi
-echo $1 |grep "^[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}$" > /dev/null
+echo "${1}" |grep "^[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}$" > /dev/null
 if [ $? = 1 ];then
 	echo version 0~999 and must 3 version eg:1.1.1
 	echo ./mkfw.sh "<version>"
@@ -30,14 +30,13 @@ echo "Date: ${date}"
 echo "build fw"
 make -C buildroot bmc-rebuild V=1
 make -C buildroot V=1
-echo "cp -rf buildroot/output/images/buildroot_linux_nand_uart3.img ./build/${date}/turingpi-${version}.img"
-cp -rf buildroot/output/images/buildroot_linux_nand_uart3.img ./build/${date}/turingpi-${version}.img
+cp -vrf buildroot/output/images/buildroot_linux_nand_uart3.img "./build/${date}/turingpi-${version}.img"
 
-cd buildroot/output/images/
+cd buildroot/output/images/ || exit 1
 ./genSWU.sh
-cd -
+cd - || exit 1
 
-cp -rf ./buildroot/output/images/turingpi_.swu ./build/${date}/turingpi-${version}.swu
+cp -vrf ./buildroot/output/images/turingpi_.swu ."/build/${date}/turingpi-${version}.swu"
 
 echo "build turing pi firmware over"
 if [ ! -f "build/tpi/linux/tpi" ];then


### PR DESCRIPTION
This adds a shellcheck github action and a companion dependabot action to keep it--and future Github Actions updated.

This also edits one of the first shell scripts I saw, to show some of the errors it can catch, which will provide an overall safer and more consistent experience with shell scripts that drive any part of the software.